### PR TITLE
Remove Players List From Game Map

### DIFF
--- a/game_score_umbrella/apps/game_score/lib/game_score.ex
+++ b/game_score_umbrella/apps/game_score/lib/game_score.ex
@@ -98,6 +98,20 @@ defmodule GameScore do
   end
 
   @doc """
+  Get a list of all players in a game.
+
+  ## Parameters
+
+    - game_name: A unique string that is the name of the game.
+  """
+  def get_player_list(game_name) do
+    case get_game(game_name) do
+      %{} = game -> Enum.map(game, fn {k, _} -> k end)
+      {:error, _} = response -> response
+    end
+  end
+
+  @doc """
   End a game.
 
   ## Parameters

--- a/game_score_umbrella/apps/game_score/lib/game_score/core/game.ex
+++ b/game_score_umbrella/apps/game_score/lib/game_score/core/game.ex
@@ -15,9 +15,9 @@ defmodule GameScore.Core.Game do
   ## Examples
 
     iex> GameScore.Core.Game.new()
-    %{players: []}
+    %{}
   """
-  def new(), do: %{players: []}
+  def new(), do: %{}
 
   @doc """
   Add a player to the game. This can be done by providing a string for the
@@ -30,12 +30,12 @@ defmodule GameScore.Core.Game do
 
   ## Examples
 
-    iex> GameScore.Core.Game.add_player(%{players: []}, "Sam")
-    %{:players => ["Sam"], "Sam" => %GameScore.Core.Player{name: "Sam", scores: []}}
+    iex> GameScore.Core.Game.add_player(%{}, "Sam")
+    %{"Sam" => %GameScore.Core.Player{name: "Sam", scores: []}}
 
     iex> player = %GameScore.Core.Player{name: "Team Joe", scores: []}
-    iex> GameScore.Core.Game.add_player(%{players: []}, player)
-    %{:players => ["Team Joe"], "Team Joe" => %GameScore.Core.Player{name: "Team Joe", scores: []}}
+    iex> GameScore.Core.Game.add_player(%{}, player)
+    %{"Team Joe" => %GameScore.Core.Player{name: "Team Joe", scores: []}}
   """
   def add_player(%{} = game, name) when is_binary(name) do
     {:ok, player} = GameScore.Core.Player.new(name)
@@ -44,13 +44,8 @@ defmodule GameScore.Core.Game do
 
   def add_player(%{} = game, %GameScore.Core.Player{} = player) do
     case Map.get(game, player.name) do
-      nil ->
-        game
-        |> Map.put(player.name, player)
-        |> Map.update(:players, [], &[player.name | &1])
-
-      _ ->
-        {:error, "player already exists"}
+      nil -> Map.put(game, player.name, player)
+      _ -> {:error, "player already exists"}
     end
   end
 end

--- a/game_score_umbrella/apps/game_score/test/boundary/game_session_test.exs
+++ b/game_score_umbrella/apps/game_score/test/boundary/game_session_test.exs
@@ -14,7 +14,6 @@ defmodule GameScore.Boundary.GameSessionTest do
     {:ok, player2} = Player.new(player2_name)
 
     added_player = %{
-      :players => [player2_name, player1_name],
       player1_name => player1,
       player2_name => player2
     }
@@ -35,7 +34,6 @@ defmodule GameScore.Boundary.GameSessionTest do
     }
 
     game = %{
-      :players => [player2_name, player1_name],
       player1_name => player1,
       player2_name => player2
     }

--- a/game_score_umbrella/apps/game_score/test/core/game_test.exs
+++ b/game_score_umbrella/apps/game_score/test/core/game_test.exs
@@ -13,7 +13,7 @@ defmodule GameScore.Core.GameTest do
         Game.new()
         |> Game.add_player(player)
 
-      assert %{:players => [name], name => player} == game
+      assert %{name => player} == game
       assert {:error, "player already exists"} == Game.add_player(game, name)
     end
   end
@@ -27,17 +27,12 @@ defmodule GameScore.Core.GameTest do
         Game.new()
         |> Game.add_player(player1)
 
-      assert %{:players => [name1], name1 => player1} == game
+      assert %{name1 => player1} == game
 
       updated_game = Game.add_player(game, name2)
 
-      expected = %{
-        :players => [name2, name1],
-        name1 => player1,
-        name2 => %Player{name: name2, scores: []}
-      }
-
-      assert expected == updated_game
+      assert %{name1 => player1, name2 => %Player{name: name2, scores: []}} ==
+               updated_game
     end
   end
 end

--- a/game_score_umbrella/apps/game_score/test/game_score_test.exs
+++ b/game_score_umbrella/apps/game_score/test/game_score_test.exs
@@ -48,6 +48,16 @@ defmodule GameScoreTest do
     assert expected == result
   end
 
+  test "it can get the list of players" do
+    {game_name, player_name} = new_game_fixture()
+
+    result = GameScore.get_player_list(game_name)
+
+    expected = [player_name]
+
+    assert expected == result
+  end
+
   test "it can end the game" do
     {game_name, _} = new_game_fixture()
 

--- a/game_score_umbrella/apps/game_score/test/game_score_test.exs
+++ b/game_score_umbrella/apps/game_score/test/game_score_test.exs
@@ -42,7 +42,6 @@ defmodule GameScoreTest do
     result = GameScore.get_game(game_name)
 
     expected = %{
-      :players => [player_name],
       player_name => %Player{name: player_name, scores: []}
     }
 


### PR DESCRIPTION
Why
---

- The players list should not be part of the game response.
- The GameScore api should be responsible for providing a list of
players.

How
---

- Undo changes made earlier.
- Generate a list of players and return it.