### PR TITLE
Feature/simple api

### DIFF
--- a/game_score_umbrella/apps/game_score/mix.exs
+++ b/game_score_umbrella/apps/game_score/mix.exs
@@ -36,7 +36,7 @@ defmodule GameScore.MixProject do
   # Type `mix help deps` for examples and options.
   defp deps do
     [
-      {:stream_data, "~> 0.1", only: :test}
+      {:stream_data, "~> 0.1", only: [:dev, :test]}
     ]
   end
 

--- a/game_score_umbrella/apps/game_score_web/lib/game_score_web/controllers/game_session_controller.ex
+++ b/game_score_umbrella/apps/game_score_web/lib/game_score_web/controllers/game_session_controller.ex
@@ -1,0 +1,57 @@
+defmodule GameScoreWeb.GameSessionController do
+  use GameScoreWeb, :controller
+
+  def create(conn, %{"game_name" => game_name, "player_name" => player_name}) do
+    with {:ok, _pid} <- GameScore.new_game(game_name, player_name),
+         players <- GameScore.get_player_list(game_name) do
+      response = %{
+        game_name: game_name,
+        players: players
+      }
+
+      json(conn, response)
+    else
+      _ ->
+        error_response(
+          conn,
+          "You must provide a unique game name and a player name to create a new game session."
+        )
+    end
+  end
+
+  def delete(conn, %{"id" => game_name}) do
+    case GameScore.end_game(game_name) do
+      :ok ->
+        response = %{
+          status: :ok,
+          message: "#{game_name} was terminated."
+        }
+
+        json(conn, response)
+
+      _ ->
+        error_response(conn, "#{game_name} could not be terminated")
+    end
+  end
+
+  def show(conn, %{"id" => game_name}) do
+    case GameScore.get_game(game_name) do
+      %{} = response ->
+        json(conn, response)
+
+      {:error, _} ->
+        error_response(conn, "#{game_name} could not be found")
+    end
+  end
+
+  defp error_response(conn, message) do
+    response = %{
+      status: :error,
+      message: message
+    }
+
+    conn
+    |> put_status(500)
+    |> json(response)
+  end
+end

--- a/game_score_umbrella/apps/game_score_web/lib/game_score_web/controllers/player_controller.ex
+++ b/game_score_umbrella/apps/game_score_web/lib/game_score_web/controllers/player_controller.ex
@@ -1,0 +1,20 @@
+defmodule GameScoreWeb.PlayerController do
+  use GameScoreWeb, :controller
+
+  def create(conn, %{"game_name" => game_name, "player_name" => player_name}) do
+    case GameScore.add_player(game_name, player_name) do
+      %{} = response ->
+        json(conn, response)
+
+      {:error, _} ->
+        response = %{
+          status: :error,
+          message: "You cannot add #{player_name} to #{game_name}"
+        }
+
+        conn
+        |> put_status(500)
+        |> json(response)
+    end
+  end
+end

--- a/game_score_umbrella/apps/game_score_web/lib/game_score_web/controllers/score_controller.ex
+++ b/game_score_umbrella/apps/game_score_web/lib/game_score_web/controllers/score_controller.ex
@@ -1,0 +1,32 @@
+defmodule GameScoreWeb.ScoreController do
+  use GameScoreWeb, :controller
+
+  def create(
+        conn,
+        %{
+          "game_name" => game_name,
+          "player_name" => player_name,
+          "points" => points
+        } = score
+      ) do
+    case GameScore.add_player_score(game_name, player_name, points, Map.get(score, "note", "")) do
+      {^player_name, total_score} ->
+        response = %{
+          player_name: player_name,
+          total_score: total_score
+        }
+
+        json(conn, response)
+
+      {:error, _} ->
+        response = %{
+          status: :error,
+          message: "Could not retrieve the score for #{player_name}"
+        }
+
+        conn
+        |> put_status(500)
+        |> json(response)
+    end
+  end
+end

--- a/game_score_umbrella/apps/game_score_web/lib/game_score_web/controllers/score_controller.ex
+++ b/game_score_umbrella/apps/game_score_web/lib/game_score_web/controllers/score_controller.ex
@@ -9,7 +9,12 @@ defmodule GameScoreWeb.ScoreController do
           "points" => points
         } = score
       ) do
-    case GameScore.add_player_score(game_name, player_name, points, Map.get(score, "note", "")) do
+    case GameScore.add_player_score(
+           game_name,
+           player_name,
+           to_number(points),
+           Map.get(score, "note", "")
+         ) do
       {^player_name, total_score} ->
         response = %{
           player_name: player_name,
@@ -29,4 +34,10 @@ defmodule GameScoreWeb.ScoreController do
         |> json(response)
     end
   end
+
+  defp to_number(points) when is_integer(points), do: points
+
+  defp to_number(points) when is_binary(points), do: String.to_integer(points)
+
+  defp to_number(_), do: ""
 end

--- a/game_score_umbrella/apps/game_score_web/lib/game_score_web/router.ex
+++ b/game_score_umbrella/apps/game_score_web/lib/game_score_web/router.ex
@@ -19,8 +19,8 @@ defmodule GameScoreWeb.Router do
     get "/", PageController, :index
   end
 
-  # Other scopes may use custom stacks.
-  # scope "/api", GameScoreWeb do
-  #   pipe_through :api
-  # end
+  scope "/api", GameScoreWeb do
+    pipe_through :api
+    resources "/gamesession", GameSessionController, only: [:create, :delete, :show]
+  end
 end

--- a/game_score_umbrella/apps/game_score_web/lib/game_score_web/router.ex
+++ b/game_score_umbrella/apps/game_score_web/lib/game_score_web/router.ex
@@ -23,5 +23,6 @@ defmodule GameScoreWeb.Router do
     pipe_through :api
     resources "/game-session", GameSessionController, only: [:create, :delete, :show]
     resources "/player", PlayerController, only: [:create]
+    resources "/score", ScoreController, only: [:create]
   end
 end

--- a/game_score_umbrella/apps/game_score_web/lib/game_score_web/router.ex
+++ b/game_score_umbrella/apps/game_score_web/lib/game_score_web/router.ex
@@ -21,6 +21,7 @@ defmodule GameScoreWeb.Router do
 
   scope "/api", GameScoreWeb do
     pipe_through :api
-    resources "/gamesession", GameSessionController, only: [:create, :delete, :show]
+    resources "/game-session", GameSessionController, only: [:create, :delete, :show]
+    resources "/player", PlayerController, only: [:create]
   end
 end

--- a/game_score_umbrella/apps/game_score_web/mix.exs
+++ b/game_score_umbrella/apps/game_score_web/mix.exs
@@ -44,7 +44,8 @@ defmodule GameScoreWeb.MixProject do
       {:gettext, "~> 0.11"},
       {:game_score, in_umbrella: true},
       {:jason, "~> 1.0"},
-      {:plug_cowboy, "~> 2.0"}
+      {:plug_cowboy, "~> 2.0"},
+      {:stream_data, "~> 0.1", only: [:dev, :test]}
     ]
   end
 

--- a/game_score_umbrella/apps/game_score_web/test/game_score_web/controllers/game_session_controller_test.exs
+++ b/game_score_umbrella/apps/game_score_web/test/game_score_web/controllers/game_session_controller_test.exs
@@ -1,0 +1,72 @@
+defmodule GameScoreWeb.GameSessionControllerTest do
+  use GameScoreWeb.ConnCase
+  use ExUnitProperties
+
+  property "it can create a new game with a non empty game name and player name", %{conn: conn} do
+    check all(
+            player_name <- string(:printable, min_length: 1),
+            game_name <- string(:printable, min_length: 1)
+          ) do
+      response =
+        conn
+        |> post(
+          Routes.game_session_path(conn, :create, %{
+            "game_name" => game_name,
+            "player_name" => player_name
+          })
+        )
+        |> json_response(200)
+
+      expected = %{
+        "game_name" => game_name,
+        "players" => [player_name]
+      }
+
+      assert response == expected
+    end
+  end
+
+  property "it can delete a game that has been created", %{conn: conn} do
+    check all(
+            game_name <- string(:printable, min_length: 1),
+            player_name <- string(:printable, min_length: 1)
+          ) do
+      GameScore.new_game(game_name, player_name)
+
+      expected = %{
+        "message" => "#{game_name} was terminated.",
+        "status" => "ok"
+      }
+
+      response =
+        conn
+        |> delete(Routes.game_session_path(conn, :delete, game_name))
+        |> json_response(200)
+
+      assert response == expected
+    end
+  end
+
+  property "it can get a game that exists", %{conn: conn} do
+    check all(
+            game_name <- string(:printable, min_length: 1),
+            player_name <- string(:printable, min_length: 1)
+          ) do
+      GameScore.new_game(game_name, player_name)
+
+      expected = %{
+        player_name => %{
+          "name" => player_name,
+          "scores" => []
+        }
+      }
+
+      response =
+        conn
+        |> get(Routes.game_session_path(conn, :show, game_name))
+        |> json_response(200)
+
+      assert response == expected
+    end
+  end
+end

--- a/game_score_umbrella/apps/game_score_web/test/game_score_web/controllers/player_controller_test.exs
+++ b/game_score_umbrella/apps/game_score_web/test/game_score_web/controllers/player_controller_test.exs
@@ -1,0 +1,34 @@
+defmodule GameScoreWeb.PlayerControllerTest do
+  use GameScoreWeb.ConnCase
+  use ExUnitProperties
+
+  test "it can add a player with a non empty name to an existing game", %{conn: conn} do
+    game_name = Enum.at(StreamData.string(:printable, min_length: 1), 0)
+    player1_name = Enum.at(StreamData.string(:printable, min_length: 1), 0)
+    player2_name = Enum.at(StreamData.string(:printable, min_length: 1), 0)
+    GameScore.new_game(game_name, player1_name)
+
+    expected = %{
+      player1_name => %{
+        "name" => player1_name,
+        "scores" => []
+      },
+      player2_name => %{
+        "name" => player2_name,
+        "scores" => []
+      }
+    }
+
+    response =
+      conn
+      |> post(
+        Routes.player_path(conn, :create, %{
+          "game_name" => game_name,
+          "player_name" => player2_name
+        })
+      )
+      |> json_response(200)
+
+    assert response == expected
+  end
+end

--- a/game_score_umbrella/apps/game_score_web/test/game_score_web/controllers/score_controller_test.exs
+++ b/game_score_umbrella/apps/game_score_web/test/game_score_web/controllers/score_controller_test.exs
@@ -1,0 +1,37 @@
+defmodule GameScoreWeb.ScoreControllerTest do
+  use GameScoreWeb.ConnCase
+  use ExUnitProperties
+
+  property "it can add an integer score with or without a note", %{conn: conn} do
+    check all(
+            all_points <- list_of(integer(), max_length: 100),
+            points <- integer(),
+            note <- string(:printable)
+          ) do
+      game_name = Enum.at(StreamData.string(:printable, min_length: 1), 0)
+      player_name = Enum.at(StreamData.string(:printable, min_length: 1), 0)
+      GameScore.new_game(game_name, player_name)
+
+      Enum.each(all_points, &GameScore.add_player_score(game_name, player_name, &1))
+
+      expected = %{
+        "player_name" => player_name,
+        "total_score" => Enum.sum(all_points) + points
+      }
+
+      response =
+        conn
+        |> post(
+          Routes.score_path(conn, :create, %{
+            "game_name" => game_name,
+            "player_name" => player_name,
+            "points" => points,
+            "note" => note
+          })
+        )
+        |> json_response(200)
+
+      assert response == expected
+    end
+  end
+end


### PR DESCRIPTION
Why
---

- Users need the ability to create, read, and delete a game session.
- Users need to be able to add players to the game session so their
score can be tracked as well.
- There is no point if you cannot add a score to a player.
- The API needs tests.
- Having to specify the environment before running `mix format` is
extremely annoying.
- Need to handle points coming in as integers and strings.

How
---

- Create a controller for the game session.
- Add a route for the game session endpoints.
- Create Player controller with a create action.
- Add route for the player controller.
- Create the Score controller so that scores can be added to players.
- Add route for the score controller.
- Write controller tests for the simple API.
- Add `:stream_data` to dev and test environments.
- Handle points coming in as integer as well as a String.